### PR TITLE
Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ go get github.com/stdupp/goasciiart
 ```
 ./goarciiart -c abc.jpg(png) -w 80
 
--c path of your picture
+-p path of your picture
 -w the width of output
 ```
 


### PR DESCRIPTION
The README has a typo for the picture's flag. You have -c, but the go file has -p. I assume you wanted the -p.
